### PR TITLE
fix invalid address

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     // console
     $ php bootstrap/api.php get "/weekday/2015/5/20"
     // built-in web
-    $ php -S 0.0.0.0:8081 -t var/www/
+    $ php -S 127.0.0.1:8081 -t var/www/
 
 ## Requirements
 


### PR DESCRIPTION
`0.0.0.0` is not valid address. Some web browser (Chrome) changed to invalid `0.0.0.0`.
See more at http://en.wikipedia.org/wiki/0.0.0.0
